### PR TITLE
Fix typo in custom-layer.ipynb

### DIFF
--- a/chapter_deep-learning-computation/custom-layer.ipynb
+++ b/chapter_deep-learning-computation/custom-layer.ipynb
@@ -179,7 +179,7 @@
     "Recall that this layer requires two parameters,\n",
     "one to represent the weight and the other for the bias.\n",
     "In this implementation, we bake in the ReLU activation as a default.\n",
-    "This layer requires to input arguments: `in_units` and `units`, which\n",
+    "This layer requires two input arguments: `in_units` and `units`, which\n",
     "denote the number of inputs and outputs, respectively.\n"
    ]
   },


### PR DESCRIPTION
Replace `to` with `two` as the text is referring to the number of input arguments to the layer.